### PR TITLE
Added support for numpy>=2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install cffi cibuildwheel wheel
+          pip install cffi setuptools distutils cibuildwheel wheel
       - name: Build and test wheels
         env:
           CIBW_ARCHS: "auto64"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,33 +6,48 @@ on:
     paths-ignore:
       - "**/**.md"
   workflow_dispatch:
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, ubuntu-22.04-arm64, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.9]
 
     if: startsWith(github.event.head_commit.message, 'Release') || github.event_name == 'workflow_dispatch'
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade setuptools wheel cffi cibuildwheel
+          python -m pip install --upgrade pip setuptools wheel cffi
+
+      - name: Fix distutils for Windows
+        if: runner.os == 'Windows'
+        run: |
+          python -m pip install --upgrade setuptools wheel
+          python -m pip install --upgrade setuptools==58.2.0  # Known stable version with distutils
+      
+      - name: Install MSVC Build Tools (Windows only)
+        if: runner.os == 'Windows'
+        run: |
+          choco install visualstudio2019buildtools --params "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+
       - name: Build and test wheels
         env:
           CIBW_ARCHS: "auto64"
           CIBW_SKIP: "cp36-* cp37-* cp38-* pp37-* pp38-* pp310-*"
-          CIBW_BEFORE_BUILD: "pip install --upgrade setuptools wheel"
           CC: clang
+          CIBW_BEFORE_BUILD: "pip install --upgrade setuptools wheel"
         run: |
           python -m cibuildwheel --output-dir wheelhouse
+
       - name: Save Wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install cffi setuptools cibuildwheel wheel
+          pip install --upgrade setuptools wheel cffi cibuildwheel
       - name: Build and test wheels
         env:
           CIBW_ARCHS: "auto64"
           CIBW_SKIP: "cp36-* cp37-* cp38-* pp37-* pp38-* pp310-*"
+          CIBW_BEFORE_BUILD: "pip install --upgrade setuptools wheel"
           CC: clang
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, ubuntu-22.04-arm64, macos-13, macos-latest]
+        os: [ubuntu-latest, macos-latest]
+        arch: [x86_64, arm64]
         python-version: [3.9]
 
     if: startsWith(github.event.head_commit.message, 'Release') || github.event_name == 'workflow_dispatch'
@@ -28,7 +29,7 @@ jobs:
       - name: Build and test wheels
         env:
           CIBW_ARCHS: "auto64"
-          CIBW_SKIP: "cp36-* cp37-* cp38-* pp37-* pp38-* pp310-*"
+          CIBW_SKIP: "cp36-* cp37-* cp38-* pp37-* pp38-* pp313-* cp313-*"
           CC: clang
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,48 +6,32 @@ on:
     paths-ignore:
       - "**/**.md"
   workflow_dispatch:
-
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, ubuntu-22.04-arm64, macos-13, macos-latest]
         python-version: [3.9]
 
     if: startsWith(github.event.head_commit.message, 'Release') || github.event_name == 'workflow_dispatch'
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel cffi
-
-      - name: Fix distutils for Windows
-        if: runner.os == 'Windows'
-        run: |
-          python -m pip install --upgrade setuptools wheel
-          python -m pip install --upgrade setuptools==58.2.0  # Known stable version with distutils
-      
-      - name: Install MSVC Build Tools (Windows only)
-        if: runner.os == 'Windows'
-        run: |
-          choco install visualstudio2019buildtools --params "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
-
+          python -m pip install --upgrade pip
+          pip install cffi cibuildwheel wheel
       - name: Build and test wheels
         env:
           CIBW_ARCHS: "auto64"
           CIBW_SKIP: "cp36-* cp37-* cp38-* pp37-* pp38-* pp310-*"
           CC: clang
-          CIBW_BEFORE_BUILD: "pip install --upgrade setuptools wheel"
         run: |
           python -m cibuildwheel --output-dir wheelhouse
-
       - name: Save Wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install cffi setuptools distutils cibuildwheel wheel
+          pip install cffi setuptools cibuildwheel wheel
       - name: Build and test wheels
         env:
           CIBW_ARCHS: "auto64"

--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,3 @@ cython_debug/
 
 # Dynamically generated version file
 numpy_rms/_version.py
-.qodo

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 
 # Dynamically generated version file
 numpy_rms/_version.py
+.qodo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.2"
 description = "A fast python library for calculating the RMS of a NumPy array"
 dependencies = [
     "cffi>=1.0.0",
-    "numpy>=1.21,<2"
+    "numpy>=1.21"
 ]
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
This addresses issue https://github.com/nomonosound/numpy-rms/issues/9

All local unit tests pass. Compatibility with numpy>=1.21 should be maintained